### PR TITLE
Fix issue #20 and #21

### DIFF
--- a/multi-view-adapter/src/main/java/com/ahamed/multiviewadapter/CoreRecyclerAdapter.java
+++ b/multi-view-adapter/src/main/java/com/ahamed/multiviewadapter/CoreRecyclerAdapter.java
@@ -110,7 +110,12 @@ class CoreRecyclerAdapter extends RecyclerView.Adapter<BaseViewHolder> {
       if (adapterPosition < totalCount) {
         int itemPosition = getItemPositionInManager(adapterPosition);
         if (dataManager instanceof DataGroupManager) {
-          dataManager = ((DataGroupManager) dataManager).getDataManagerForPosition(itemPosition);
+          DataGroupManager groupManager = (DataGroupManager) dataManager;
+          if (itemPosition < groupManager.getHeaderItemSize()) {
+            dataManager = groupManager.getHeaderItemManager();
+          } else {
+            itemPosition -= groupManager.getHeaderItemSize();
+          }
         }
         //noinspection unchecked
         holder.setItem(dataManager.get(itemPosition));
@@ -146,8 +151,13 @@ class CoreRecyclerAdapter extends RecyclerView.Adapter<BaseViewHolder> {
 
   ItemBinder getBinderForPosition(int adapterPosition) {
     BaseDataManager dataManager = getDataManager(adapterPosition);
+    int skipHeaderItemSize = 0;
+    if (dataManager instanceof DataGroupManager) {
+      skipHeaderItemSize = ((DataGroupManager) dataManager).getHeaderItemSize();
+    }
     for (ItemBinder baseBinder : binders) {
-      if (baseBinder.canBindData(dataManager.get(getItemPositionInManager(adapterPosition)))) {
+      int itemPosition = getItemPositionInManager(adapterPosition) - skipHeaderItemSize;
+      if (baseBinder.canBindData(dataManager.get(itemPosition))) {
         return baseBinder;
       }
     }

--- a/multi-view-adapter/src/main/java/com/ahamed/multiviewadapter/DataGroupManager.java
+++ b/multi-view-adapter/src/main/java/com/ahamed/multiviewadapter/DataGroupManager.java
@@ -55,11 +55,19 @@ public class DataGroupManager<H, M> extends DataListUpdateManager<M> {
   }
 
   BaseDataManager getDataManagerForPosition(int itemPositionInManager) {
-    if (itemPositionInManager == 0) {
+    if (itemPositionInManager < headerItemManager.size()) {
       return headerItemManager;
     } else {
       return this;
     }
+  }
+
+  public BaseDataManager getHeaderItemManager() {
+    return headerItemManager;
+  }
+
+  public int getHeaderItemSize() {
+    return headerItemManager.size();
   }
 
   @Override int size() {

--- a/sample/src/main/java/com/ahamed/sample/complex/ComplexListActivity.java
+++ b/sample/src/main/java/com/ahamed/sample/complex/ComplexListActivity.java
@@ -40,6 +40,7 @@ public class ComplexListActivity extends BaseActivity {
     GridLayoutManager glm = new GridLayoutManager(getApplicationContext(), 3);
 
     ComplexListAdapter adapter = new ComplexListAdapter(this);
+    adapter.getItemTouchHelper().attachToRecyclerView(recyclerView);
     adapter.setSpanCount(3);
 
     glm.setSpanSizeLookup(adapter.getSpanSizeLookup());

--- a/sample/src/main/java/com/ahamed/sample/grid/GridAdapterActivity.java
+++ b/sample/src/main/java/com/ahamed/sample/grid/GridAdapterActivity.java
@@ -45,6 +45,7 @@ public class GridAdapterActivity extends BaseActivity {
     GridLayoutManager glm = new GridLayoutManager(getApplicationContext(), 3);
 
     GridAdapter adapter = new GridAdapter(convertDpToPixel(4, this));
+    adapter.getItemTouchHelper().attachToRecyclerView(recyclerView);
     adapter.setSpanCount(3);
 
     recyclerView.addItemDecoration(adapter.getItemDecorationManager());


### PR DESCRIPTION
Fix #20 :
In CoreRecyclerAdapter, `getItemPositionInManager(int adapterPosition)` return shifted item position when item is in DataGroupManager, caused by the headItemManager's size in DataGroupManager.

Fix #21 :
`GridItemBinder` in the sample app calls `startDrag();` when long click the item.

