### PR TITLE
Fix snapshot buildscript issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,12 @@ buildscript {
     classpath 'com.android.tools.build:gradle:3.3.1'
     classpath 'com.novoda:bintray-release:0.9'
     classpath 'org.jacoco:org.jacoco.core:0.8.2'
-//    classpath "guru.stefma.artifactorypublish:artifactorypublish:1.1.0"
-//    classpath "guru.stefma.bintrayrelease:bintrayrelease:1.0.0"
+    classpath "guru.stefma.artifactorypublish:artifactorypublish:1.1.0"
+  }
+  configurations.all {
+    resolutionStrategy {
+      force 'org.codehaus.groovy:groovy-all:2.4.15'
+    }
   }
 }
 

--- a/multi-view-adapter/build.gradle
+++ b/multi-view-adapter/build.gradle
@@ -18,7 +18,7 @@ import gradle.Config
 
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-//apply plugin: 'guru.stefma.artifactorypublish'
+apply plugin: 'guru.stefma.artifactorypublish'
 apply plugin: 'jacoco'
 
 jacoco {
@@ -90,12 +90,12 @@ publish {
   website = Config.WEBSITE
 }
 
-//version = Config.SNAPSHOT_VERSION
-//group = Config.GROUP_ID
-//
-//artifactoryPublish {
-//  artifactId = Config.ARTIFACT_ID_CORE
-//  artifactoryRepo = "oss-snapshot-local"
-//  artifactoryUrl = "https://oss.jfrog.org/artifactory/"
-//  publications = ["releaseAar"]
-//}
+version = Config.SNAPSHOT_VERSION
+group = Config.GROUP_ID
+
+artifactoryPublish {
+  artifactId = Config.ARTIFACT_ID_CORE
+  artifactoryRepo = "oss-snapshot-local"
+  artifactoryUrl = "https://oss.jfrog.org/artifactory/"
+  publications = ["releaseAar"]
+}


### PR DESCRIPTION
groovy-all package which is used by artifactory plugin and jacoco plugin has mismatching versions. Forcing them to use the same version will resolve the issue.