### PR TITLE
Fix javadoc html generation

### DIFF
--- a/extensions/databinding/build.gradle
+++ b/extensions/databinding/build.gradle
@@ -68,3 +68,39 @@ publish {
 //  artifactoryUrl = "https://oss.jfrog.org/artifactory/"
 //  publications = ["releaseAar"]
 //}
+
+afterEvaluate { project ->
+  task androidJavadocs(type: Javadoc) {
+    source = android.sourceSets.main.java.source
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+  }
+
+  task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+    classifier = 'javadoc'
+    from androidJavadocs.destinationDir
+  }
+
+  task androidSourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.source
+  }
+
+  if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+      tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+      }
+    }
+  }
+
+  artifacts {
+    if (project.getPlugins().hasPlugin('com.android.application') || project.getPlugins().
+        hasPlugin('com.android.library')) {
+      archives androidSourcesJar
+      archives androidJavadocsJar
+    } else {
+      archives sourcesJar
+      archives javadocJar
+    }
+  }
+}

--- a/extensions/decorator/build.gradle
+++ b/extensions/decorator/build.gradle
@@ -61,3 +61,39 @@ publish {
 //  artifactoryUrl = "https://oss.jfrog.org/artifactory/"
 //  publications = ["releaseAar"]
 //}
+
+afterEvaluate { project ->
+  task androidJavadocs(type: Javadoc) {
+    source = android.sourceSets.main.java.source
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+  }
+
+  task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+    classifier = 'javadoc'
+    from androidJavadocs.destinationDir
+  }
+
+  task androidSourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.source
+  }
+
+  if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+      tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+      }
+    }
+  }
+
+  artifacts {
+    if (project.getPlugins().hasPlugin('com.android.application') || project.getPlugins().
+        hasPlugin('com.android.library')) {
+      archives androidSourcesJar
+      archives androidJavadocsJar
+    } else {
+      archives sourcesJar
+      archives javadocJar
+    }
+  }
+}

--- a/extensions/diffutil-rx/build.gradle
+++ b/extensions/diffutil-rx/build.gradle
@@ -63,3 +63,39 @@ publish {
 //  artifactoryUrl = "https://oss.jfrog.org/artifactory/"
 //  publications = ["releaseAar"]
 //}
+
+afterEvaluate { project ->
+  task androidJavadocs(type: Javadoc) {
+    source = android.sourceSets.main.java.source
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+  }
+
+  task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+    classifier = 'javadoc'
+    from androidJavadocs.destinationDir
+  }
+
+  task androidSourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.source
+  }
+
+  if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+      tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+      }
+    }
+  }
+
+  artifacts {
+    if (project.getPlugins().hasPlugin('com.android.application') || project.getPlugins().
+        hasPlugin('com.android.library')) {
+      archives androidSourcesJar
+      archives androidJavadocsJar
+    } else {
+      archives sourcesJar
+      archives javadocJar
+    }
+  }
+}

--- a/multi-view-adapter/.gitignore
+++ b/multi-view-adapter/.gitignore
@@ -1,1 +1,2 @@
 /build
+/javadocs

--- a/multi-view-adapter/build.gradle
+++ b/multi-view-adapter/build.gradle
@@ -99,3 +99,40 @@ artifactoryPublish {
   artifactoryUrl = "https://oss.jfrog.org/artifactory/"
   publications = ["releaseAar"]
 }
+
+afterEvaluate { project ->
+  task androidJavadocs(type: Javadoc) {
+    source = android.sourceSets.main.java.source
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+  }
+
+  task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+    androidJavadocs.setDestinationDir(file("javadocs"))
+    classifier = 'javadoc'
+    from androidJavadocs.destinationDir
+  }
+
+  task androidSourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.source
+  }
+
+  if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+      tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+      }
+    }
+  }
+
+  artifacts {
+    if (project.getPlugins().hasPlugin('com.android.application') || project.getPlugins().
+        hasPlugin('com.android.library')) {
+      archives androidSourcesJar
+      archives androidJavadocsJar
+    } else {
+      archives sourcesJar
+      archives javadocJar
+    }
+  }
+}


### PR DESCRIPTION
This pr fixes the javadoc html files generation. For adapter module, target path for generated html files is git-ignored. This avoids polluting the diff in commits. For now we have to manually copy these generated files to 'gh-pages' (documentation) branch.