### PR TITLE
Fixes incorrect 'selection' and 'expansion' behaviour

### DIFF
--- a/multi-view-adapter/src/main/java/mva2/adapter/NestedSection.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/NestedSection.java
@@ -201,7 +201,9 @@ public class NestedSection extends Section implements Notifier {
   }
 
   @Override void onItemSelectionToggled(int itemPosition, @NonNull Mode selectionMode) {
-    Mode selectionModeToHonor = getModeToHonor(selectionMode, this.selectionMode);
+    Mode selectionModeToHonor =
+        itemPosition < getCount() && itemPosition >= 0 ? getModeToHonor(selectionMode,
+            this.selectionMode) : selectionMode;
     for (Section section : sections) {
       section.onItemSelectionToggled(itemPosition, selectionModeToHonor);
       itemPosition -= section.getCount();
@@ -229,7 +231,9 @@ public class NestedSection extends Section implements Notifier {
   }
 
   @Override void onItemExpansionToggled(int itemPosition, @NonNull Mode expansionMode) {
-    Mode expansionModeToHonor = getModeToHonor(expansionMode, this.expansionMode);
+    Mode expansionModeToHonor =
+        itemPosition < getCount() && itemPosition >= 0 ? getModeToHonor(expansionMode,
+            this.expansionMode) : expansionMode;
     for (Section section : sections) {
       section.onItemExpansionToggled(itemPosition, expansionModeToHonor);
       itemPosition -= section.getCount();

--- a/multi-view-adapter/src/test/java/mva2/adapter/CoreExpansionTest.java
+++ b/multi-view-adapter/src/test/java/mva2/adapter/CoreExpansionTest.java
@@ -17,6 +17,7 @@
 package mva2.adapter;
 
 import mva2.adapter.util.Mode;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -123,9 +124,10 @@ import static junit.framework.Assert.assertTrue;
     assertTrue(adapter.isItemExpanded(1));
   }
 
-  @Test public void expansionModeTest_SectionSingle() {
+  @Test public void selectionModeTest_SectionSingle() {
     adapter.setExpansionMode(Mode.MULTIPLE);
-    headerSection1.setExpansionMode(Mode.SINGLE);
+    listSection1.setExpansionMode(Mode.SINGLE);
+    headerSection1.getListSection().setExpansionMode(Mode.SINGLE);
     adapter.onItemExpansionToggled(1);
     assertTrue(adapter.isItemExpanded(1));
 
@@ -135,7 +137,25 @@ import static junit.framework.Assert.assertTrue;
 
     adapter.onItemExpansionToggled(23);
     assertTrue(adapter.isItemExpanded(23));
-    assertTrue(!adapter.isItemExpanded(22));
+    Assert.assertFalse(adapter.isItemExpanded(22));
+    assertTrue(adapter.isItemExpanded(1));
+  }
+
+  @Test public void selectionModeTest_SectionSingle_1() {
+    adapter.setExpansionMode(Mode.MULTIPLE);
+    listSection1.setExpansionMode(Mode.SINGLE);
+    headerSection1.getListSection().setExpansionMode(Mode.SINGLE);
+
+    adapter.onItemExpansionToggled(22);
+    assertTrue(adapter.isItemExpanded(22));
+
+    adapter.onItemExpansionToggled(1);
+    assertTrue(adapter.isItemExpanded(22));
+    assertTrue(adapter.isItemExpanded(1));
+
+    adapter.onItemExpansionToggled(23);
+    assertTrue(adapter.isItemExpanded(23));
+    assertFalse(adapter.isItemExpanded(22));
     assertTrue(adapter.isItemExpanded(1));
   }
 

--- a/multi-view-adapter/src/test/java/mva2/adapter/CoreSelectionTest.java
+++ b/multi-view-adapter/src/test/java/mva2/adapter/CoreSelectionTest.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(MockitoJUnitRunner.class) public class CoreSelectionTest extends BaseTest {
 
@@ -119,6 +120,7 @@ import static junit.framework.Assert.assertTrue;
   @Test public void selectionModeTest_SectionSingle() {
     adapter.setSelectionMode(Mode.MULTIPLE);
     listSection1.setSelectionMode(Mode.SINGLE);
+    headerSection1.getListSection().setSelectionMode(Mode.SINGLE);
     adapter.onItemSelectionToggled(1);
     assertTrue(adapter.isItemSelected(1));
 
@@ -128,7 +130,25 @@ import static junit.framework.Assert.assertTrue;
 
     adapter.onItemSelectionToggled(23);
     assertTrue(adapter.isItemSelected(23));
+    assertFalse(adapter.isItemSelected(22));
+    assertTrue(adapter.isItemSelected(1));
+  }
+
+  @Test public void selectionModeTest_SectionSingle_1() {
+    adapter.setSelectionMode(Mode.MULTIPLE);
+    listSection1.setSelectionMode(Mode.SINGLE);
+    headerSection1.getListSection().setSelectionMode(Mode.SINGLE);
+
+    adapter.onItemSelectionToggled(22);
     assertTrue(adapter.isItemSelected(22));
+
+    adapter.onItemSelectionToggled(1);
+    assertTrue(adapter.isItemSelected(22));
+    assertTrue(adapter.isItemSelected(1));
+
+    adapter.onItemSelectionToggled(23);
+    assertTrue(adapter.isItemSelected(23));
+    assertFalse(adapter.isItemSelected(22));
     assertTrue(adapter.isItemSelected(1));
   }
 


### PR DESCRIPTION
When the sections have selection/expansion mode as single and adapter has mode as multiple, then incorrect mode is set for adapter. This is discussed in this issue #72.