### PR TITLE
Fixes incorrect adapter position being sent while calling notify method

### DIFF
--- a/multi-view-adapter/src/main/java/mva2/adapter/ListSection.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/ListSection.java
@@ -428,9 +428,10 @@ public class ListSection<M> extends Section {
     int itemPosition = 0;
     for (ItemMetaData itemMetaData : metaDataList) {
       if (itemMetaData.isSelected()) {
-        itemMetaData.setSelected(!itemMetaData.isSelected());
-        onChanged(itemPosition++, 1, null);
+        itemMetaData.setSelected(false);
+        onChanged(itemPosition, 1, null);
       }
+      itemPosition++;
     }
   }
 
@@ -450,13 +451,13 @@ public class ListSection<M> extends Section {
   }
 
   @Override void collapseAllItems() {
-    int adapterPosition = 0;
+    int itemPosition = 0;
     for (ItemMetaData itemMetaData : metaDataList) {
       if (itemMetaData.isExpanded()) {
-        itemMetaData.setExpanded(!itemMetaData.isExpanded());
-        onChanged(adapterPosition, 1, null);
+        itemMetaData.setExpanded(false);
+        onChanged(itemPosition, 1, null);
       }
-      adapterPosition++;
+      itemPosition++;
     }
   }
 

--- a/multi-view-adapter/src/test/java/mva2/adapter/CoreSelectionTest.java
+++ b/multi-view-adapter/src/test/java/mva2/adapter/CoreSelectionTest.java
@@ -23,6 +23,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class) public class CoreSelectionTest extends BaseTest {
 
@@ -175,25 +179,22 @@ import static org.junit.Assert.assertFalse;
 
   @Test public void selectionModeTest_Notify() {
     adapter.setSelectionMode(Mode.MULTIPLE);
-    listSection1.setSelectionMode(Mode.SINGLE);
-    headerSection1.getListSection().setSelectionMode(Mode.SINGLE);
+    listSection1.setSelectionMode(Mode.MULTIPLE);
+    headerSection1.getListSection().setSelectionMode(Mode.MULTIPLE);
 
     adapter.onItemSelectionToggled(1);
-    assertTrue(adapter.isItemSelected(1));
-
     adapter.onItemSelectionToggled(41);
-    assertTrue(adapter.isItemSelected(41));
-    assertTrue(!adapter.isItemSelected(1));
-
     adapter.onItemSelectionToggled(2);
-    assertTrue(adapter.isItemSelected(2));
-    assertTrue(!adapter.isItemSelected(41));
-
     adapter.onItemSelectionToggled(25);
-    assertTrue(adapter.isItemSelected(25));
-    assertTrue(!adapter.isItemSelected(1));
+    adapter.onItemSelectionToggled(28);
 
-    adapter.onItemSelectionToggled(25);
-    assertTrue(!adapter.isItemSelected(25));
+    clearInvocations(adapterDataObserver);
+    adapter.clearAllSelections();
+
+    verify(adapterDataObserver).notifyItemRangeChanged(eq(1), eq(1), any());
+    verify(adapterDataObserver).notifyItemRangeChanged(eq(41), eq(1), any());
+    verify(adapterDataObserver).notifyItemRangeChanged(eq(2), eq(1), any());
+    verify(adapterDataObserver).notifyItemRangeChanged(eq(25), eq(1), any());
+    verify(adapterDataObserver).notifyItemRangeChanged(eq(28), eq(1), any());
   }
 }

--- a/multi-view-adapter/src/test/java/mva2/adapter/CoreSelectionTest.java
+++ b/multi-view-adapter/src/test/java/mva2/adapter/CoreSelectionTest.java
@@ -172,4 +172,28 @@ import static org.junit.Assert.assertFalse;
     adapter.onItemSelectionToggled(25);
     assertTrue(!adapter.isItemSelected(25));
   }
+
+  @Test public void selectionModeTest_Notify() {
+    adapter.setSelectionMode(Mode.MULTIPLE);
+    listSection1.setSelectionMode(Mode.SINGLE);
+    headerSection1.getListSection().setSelectionMode(Mode.SINGLE);
+
+    adapter.onItemSelectionToggled(1);
+    assertTrue(adapter.isItemSelected(1));
+
+    adapter.onItemSelectionToggled(41);
+    assertTrue(adapter.isItemSelected(41));
+    assertTrue(!adapter.isItemSelected(1));
+
+    adapter.onItemSelectionToggled(2);
+    assertTrue(adapter.isItemSelected(2));
+    assertTrue(!adapter.isItemSelected(41));
+
+    adapter.onItemSelectionToggled(25);
+    assertTrue(adapter.isItemSelected(25));
+    assertTrue(!adapter.isItemSelected(1));
+
+    adapter.onItemSelectionToggled(25);
+    assertTrue(!adapter.isItemSelected(25));
+  }
 }


### PR DESCRIPTION
When 'clearAllSelections' method is called on a ListSection, notify method is called with incorrect position. This commit fixes the issue.