### PR TITLE
Send pre-defined payload when item's selection/expansion is toggled

### DIFF
--- a/multi-view-adapter/src/main/java/mva2/adapter/HeaderSection.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/HeaderSection.java
@@ -115,7 +115,7 @@ public class HeaderSection<H, M> extends NestedSection implements Notifier {
     if (listSection.isSectionExpanded()) {
       listSection.setSectionExpanded(false);
       onRemoved(1, listSection.size());
-      onChanged(0, 1, null);
+      onChanged(0, 1, SECTION_EXPANSION_PAYLOAD);
     }
   }
 
@@ -135,12 +135,12 @@ public class HeaderSection<H, M> extends NestedSection implements Notifier {
           } else {
             onRemoved(1, listSection.size());
           }
-          onChanged(0, 1, null);
+          onChanged(0, 1, SECTION_EXPANSION_PAYLOAD);
         } else {
           if (listSection.isSectionExpanded()) {
             listSection.setSectionExpanded(!listSection.isSectionExpanded());
             onRemoved(1, listSection.size());
-            onChanged(0, 1, null);
+            onChanged(0, 1, SECTION_EXPANSION_PAYLOAD);
           }
         }
         return itemPosition - prevCount;
@@ -152,7 +152,7 @@ public class HeaderSection<H, M> extends NestedSection implements Notifier {
           } else {
             onRemoved(1, listSection.size());
           }
-          onChanged(0, 1, null);
+          onChanged(0, 1, SECTION_EXPANSION_PAYLOAD);
         }
         return itemPosition - prevCount;
       case NONE:

--- a/multi-view-adapter/src/main/java/mva2/adapter/ItemBinder.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/ItemBinder.java
@@ -18,13 +18,13 @@ package mva2.adapter;
 
 import android.graphics.Canvas;
 import android.graphics.Rect;
+import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.support.annotation.LayoutRes;
-import android.support.v7.widget.RecyclerView;
 import java.util.ArrayList;
 import java.util.List;
 import mva2.adapter.decorator.Decorator;

--- a/multi-view-adapter/src/main/java/mva2/adapter/ItemSection.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/ItemSection.java
@@ -120,10 +120,10 @@ import mva2.adapter.util.Mode;
       Mode modeToHonor = getModeToHonor(selectionMode, this.selectionMode);
       if (modeToHonor == Mode.SINGLE && itemMetaData.isSelected()) {
         itemMetaData.setSelected(!itemMetaData.isSelected());
-        onChanged(0, 1, null);
+        onChanged(0, 1, SELECTION_PAYLOAD);
       } else if (itemPosition < getCount() && itemPosition >= 0) {
         itemMetaData.setSelected(!itemMetaData.isSelected());
-        onChanged(0, 1, null);
+        onChanged(0, 1, SELECTION_PAYLOAD);
       }
     }
   }
@@ -132,7 +132,7 @@ import mva2.adapter.util.Mode;
     if (itemMetaData.isSelected()) {
       itemMetaData.setSelected(!itemMetaData.isSelected());
       if (isItemShowing()) {
-        onChanged(0, 1, null);
+        onChanged(0, 1, SELECTION_PAYLOAD);
       }
     }
   }
@@ -146,10 +146,10 @@ import mva2.adapter.util.Mode;
       Mode modeToHonor = getModeToHonor(selectionMode, this.expansionMode);
       if (modeToHonor == Mode.SINGLE && itemMetaData.isExpanded()) {
         itemMetaData.setExpanded(!itemMetaData.isExpanded());
-        onChanged(0, 1, null);
+        onChanged(0, 1, ITEM_EXPANSION_PAYLOAD);
       } else if (itemPosition < getCount() && itemPosition >= 0) {
         itemMetaData.setExpanded(!itemMetaData.isExpanded());
-        onChanged(0, 1, null);
+        onChanged(0, 1, ITEM_EXPANSION_PAYLOAD);
       }
     }
   }
@@ -158,7 +158,7 @@ import mva2.adapter.util.Mode;
     if (itemMetaData.isExpanded()) {
       itemMetaData.setExpanded(!itemMetaData.isExpanded());
       if (isItemShowing()) {
-        onChanged(0, 1, null);
+        onChanged(0, 1, ITEM_EXPANSION_PAYLOAD);
       }
     }
   }

--- a/multi-view-adapter/src/main/java/mva2/adapter/ItemViewHolder.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/ItemViewHolder.java
@@ -16,8 +16,8 @@
 
 package mva2.adapter;
 
-import android.view.View;
 import android.support.v7.widget.RecyclerView;
+import android.view.View;
 import mva2.adapter.util.OnItemClickListener;
 
 /**

--- a/multi-view-adapter/src/main/java/mva2/adapter/ListSection.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/ListSection.java
@@ -18,8 +18,8 @@ package mva2.adapter;
 
 import android.support.annotation.NonNull;
 import android.support.v7.util.DiffUtil;
-import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.util.ListUpdateCallback;
+import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.LayoutManager;
 import android.support.v7.widget.SpanSizeLookup;
@@ -429,7 +429,7 @@ public class ListSection<M> extends Section {
     for (ItemMetaData itemMetaData : metaDataList) {
       if (itemMetaData.isSelected()) {
         itemMetaData.setSelected(false);
-        onChanged(itemPosition, 1, null);
+        onChanged(itemPosition, 1, SELECTION_PAYLOAD);
       }
       itemPosition++;
     }
@@ -455,7 +455,7 @@ public class ListSection<M> extends Section {
     for (ItemMetaData itemMetaData : metaDataList) {
       if (itemMetaData.isExpanded()) {
         itemMetaData.setExpanded(false);
-        onChanged(itemPosition, 1, null);
+        onChanged(itemPosition, 1, ITEM_EXPANSION_PAYLOAD);
       }
       itemPosition++;
     }
@@ -605,15 +605,15 @@ public class ListSection<M> extends Section {
       if (count == itemPosition) {
         if (itemMetaData.isExpanded()) {
           itemMetaData.setExpanded(!itemMetaData.isExpanded());
-          onChanged(count, 1, null);
+          onChanged(count, 1, ITEM_EXPANSION_PAYLOAD);
           break;
         } else {
           itemMetaData.setExpanded(!itemMetaData.isExpanded());
-          onChanged(count, 1, null);
+          onChanged(count, 1, ITEM_EXPANSION_PAYLOAD);
         }
       } else if (itemMetaData.isExpanded()) {
         itemMetaData.setExpanded(false);
-        onChanged(count, 1, null);
+        onChanged(count, 1, ITEM_EXPANSION_PAYLOAD);
         if (itemPosition < 0) {
           break;
         }
@@ -628,18 +628,18 @@ public class ListSection<M> extends Section {
       if (count == itemPosition) {
         if (itemMetaData.isSelected()) {
           itemMetaData.setSelected(!itemMetaData.isSelected());
-          onChanged(count, 1, null);
+          onChanged(count, 1, SELECTION_PAYLOAD);
           notifySelectionChanged(count);
           break;
         } else {
           itemMetaData.setSelected(!itemMetaData.isSelected());
-          onChanged(count, 1, null);
+          onChanged(count, 1, SELECTION_PAYLOAD);
           notifySelectionChanged(count);
           itemPosition = -1;
         }
       } else if (itemMetaData.isSelected()) {
         itemMetaData.setSelected(false);
-        onChanged(count, 1, null);
+        onChanged(count, 1, SELECTION_PAYLOAD);
         notifySelectionChanged(count);
       }
       count++;
@@ -650,7 +650,7 @@ public class ListSection<M> extends Section {
     if (itemPosition < getCount() && itemPosition >= 0) {
       ItemMetaData itemMetaData = metaDataList.get(itemPosition);
       itemMetaData.setExpanded(!itemMetaData.isExpanded());
-      onChanged(itemPosition, 1, null);
+      onChanged(itemPosition, 1, ITEM_EXPANSION_PAYLOAD);
     }
   }
 
@@ -658,7 +658,7 @@ public class ListSection<M> extends Section {
     if (itemPosition < getCount() && itemPosition >= 0) {
       ItemMetaData itemMetaData = metaDataList.get(itemPosition);
       itemMetaData.setSelected(!itemMetaData.isSelected());
-      onChanged(itemPosition, 1, null);
+      onChanged(itemPosition, 1, SELECTION_PAYLOAD);
       notifySelectionChanged(itemPosition);
     }
   }

--- a/multi-view-adapter/src/main/java/mva2/adapter/NestedSection.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/NestedSection.java
@@ -18,11 +18,11 @@ package mva2.adapter;
 
 import android.graphics.Canvas;
 import android.graphics.Rect;
-import android.view.View;
 import android.support.annotation.NonNull;
 import android.support.annotation.RestrictTo;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.LayoutManager;
+import android.view.View;
 import java.util.ArrayList;
 import java.util.List;
 import mva2.adapter.decorator.PositionType;

--- a/multi-view-adapter/src/main/java/mva2/adapter/Section.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/Section.java
@@ -18,13 +18,13 @@ package mva2.adapter;
 
 import android.graphics.Canvas;
 import android.graphics.Rect;
-import android.view.View;
 import android.support.annotation.NonNull;
 import android.support.annotation.RestrictTo;
-import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.util.ListUpdateCallback;
+import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.LayoutManager;
+import android.view.View;
 import java.util.ArrayList;
 import java.util.List;
 import mva2.adapter.decorator.Decorator;
@@ -58,6 +58,21 @@ import static mva2.adapter.util.Mode.INHERIT;
  * section implementation.
  */
 public abstract class Section implements ListUpdateCallback {
+
+  /**
+   * String which is sent as payload object when item selection is changed
+   */
+  public static final String SELECTION_PAYLOAD = "selection_payload";
+
+  /**
+   * String which is sent as payload object when item expansion is changed
+   */
+  public static final String ITEM_EXPANSION_PAYLOAD = "item_expansion_payload";
+
+  /**
+   * String which is sent as payload object when section expansion is changed
+   */
+  public static final String SECTION_EXPANSION_PAYLOAD = "section_expansion_payload";
 
   @NonNull Mode selectionMode = INHERIT;
   @NonNull Mode expansionMode = INHERIT;

--- a/multi-view-adapter/src/main/java/mva2/adapter/decorator/Decorator.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/decorator/Decorator.java
@@ -18,11 +18,11 @@ package mva2.adapter.decorator;
 
 import android.graphics.Canvas;
 import android.graphics.Rect;
-import android.view.View;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.view.View;
 import mva2.adapter.ItemBinder;
 import mva2.adapter.MultiViewAdapter;
 import mva2.adapter.Section;

--- a/multi-view-adapter/src/main/java/mva2/adapter/util/InfiniteLoadingHelper.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/util/InfiniteLoadingHelper.java
@@ -16,13 +16,13 @@
 
 package mva2.adapter.util;
 
-import android.view.ViewGroup;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.RestrictTo;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.StaggeredGridLayoutManager;
+import android.view.ViewGroup;
 import mva2.adapter.ItemBinder;
 import mva2.adapter.ItemSection;
 import mva2.adapter.ItemViewHolder;


### PR DESCRIPTION
When the item's selection/expansion is changed the 'notifyItemChanged' method is called. Previously the notify method was called with null payload. With this commit, now the notify method will be called with constant string as payload.