### PR TITLE
TreeSection's behavior changed for decoration, default expansion status

### DIFF
--- a/multi-view-adapter/src/main/java/mva2/adapter/TreeSection.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/TreeSection.java
@@ -16,7 +16,11 @@
 
 package mva2.adapter;
 
+import android.graphics.Canvas;
+import android.graphics.Rect;
 import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
 import mva2.adapter.decorator.Decorator;
 import mva2.adapter.decorator.SectionPositionType;
 import mva2.adapter.internal.Notifier;
@@ -40,8 +44,12 @@ public class TreeSection<M> extends NestedSection implements Notifier {
 
   /**
    * Constructor which initializes TreeSection with an item.
+   *
+   * @param item       Item to be set for this TreeSection
+   * @param isExpanded If true, TreeSection is expanded and added to adapter. If false, the
+   *                   TreeSection is collapsed and added to the adapter.
    */
-  public TreeSection(M item) {
+  public TreeSection(M item, boolean isExpanded) {
     super();
 
     itemSection = new ItemSection<>(item);
@@ -50,6 +58,7 @@ public class TreeSection<M> extends NestedSection implements Notifier {
     sections.add(itemSection);
 
     setSectionExpansionMode(Mode.MULTIPLE);
+    setSectionExpanded(isExpanded);
   }
 
   /**
@@ -122,7 +131,7 @@ public class TreeSection<M> extends NestedSection implements Notifier {
   }
 
   @Override int getCount() {
-    if (isSectionVisible()) {
+    if (isSectionExpanded()) {
       return super.getCount();
     } else {
       return itemSection.getCount();
@@ -144,6 +153,7 @@ public class TreeSection<M> extends NestedSection implements Notifier {
         } else {
           onRemoved(1, count);
         }
+        onChanged(0, 1, SECTION_EXPANSION_PAYLOAD);
       } else {
         onChildSectionExpansionToggled(itemPosition, this.sectionExpansionMode);
       }
@@ -151,9 +161,50 @@ public class TreeSection<M> extends NestedSection implements Notifier {
     return itemPosition - getCount();
   }
 
+  @Override void drawDecoration(int itemPosition, @NonNull Canvas canvas,
+      @NonNull RecyclerView parent, @NonNull RecyclerView.State state, View child,
+      int adapterPosition) {
+    if (itemPosition != 0) {
+      drawChildSectionDecoration(itemPosition, canvas, parent, state, child, adapterPosition);
+    } else if (null != treeDecorator) {
+      treeDecorator.onDraw(canvas, parent, state, child, adapterPosition);
+    }
+  }
+
+  @Override void drawDecorationOver(int itemPosition, @NonNull Canvas canvas,
+      @NonNull RecyclerView parent, @NonNull RecyclerView.State state, View child,
+      int adapterPosition) {
+    if (itemPosition != 0) {
+      drawChildSectionDecorationOver(itemPosition, canvas, parent, state, child, adapterPosition);
+    } else if (null != treeDecorator) {
+      treeDecorator.onDrawOver(canvas, parent, state, child, adapterPosition);
+    }
+  }
+
+  @Override void getDecorationOffsets(int itemPosition, @NonNull Rect outRect, @NonNull View view,
+      @NonNull RecyclerView parent, @NonNull RecyclerView.State state, int adapterPosition) {
+    if (null != treeDecorator) {
+      treeDecorator.getItemOffsets(outRect, view, parent, state, adapterPosition);
+    }
+    if (itemPosition != 0) {
+      getChildSectionOffsets(itemPosition, outRect, view, parent, state, adapterPosition);
+    }
+  }
+
+  @Override boolean isSectionExpanded(int itemPosition) {
+    if (itemPosition == 0) {
+      return isSectionExpanded();
+    }
+    return super.isSectionExpanded(itemPosition);
+  }
+
+  boolean isSectionVisible() {
+    return !isSectionHidden();
+  }
+
   private void addTreeSection(TreeSection section) {
     section.setNotifier(this);
-    section.addDecorator(treeDecorator);
+    section.setTreeDecorator(treeDecorator);
     sections.add(section);
   }
 

--- a/multi-view-adapter/src/test/java/mva2/adapter/BaseTest.java
+++ b/multi-view-adapter/src/test/java/mva2/adapter/BaseTest.java
@@ -175,14 +175,14 @@ import org.mockito.Spy;
     headerSection2.getListSection().set(testItemList4);
 
     // TREE SECTION 1
-    treeSection1 = new TreeSection<>(new Comment(49, "Author 49", "Comment 49"));
-    treeSection2 = new TreeSection<>(new Comment(50, "Author 50", "Comment 50"));
-    treeSection3 = new TreeSection<>(new Comment(51, "Author 51", "Comment 51"));
-    treeSection4 = new TreeSection<>(new Comment(52, "Author 52", "Comment 52"));
-    treeSection5 = new TreeSection<>(new Comment(53, "Author 53", "Comment 53"));
-    treeSection6 = new TreeSection<>(new Comment(54, "Author 54", "Comment 54"));
-    treeSection7 = new TreeSection<>(new Comment(55, "Author 55", "Comment 55"));
-    treeSection8 = new TreeSection<>(new Comment(56, "Author 56", "Comment 56"));
+    treeSection1 = new TreeSection<>(new Comment(49, "Author 49", "Comment 49"), true);
+    treeSection2 = new TreeSection<>(new Comment(50, "Author 50", "Comment 50"), true);
+    treeSection3 = new TreeSection<>(new Comment(51, "Author 51", "Comment 51"), true);
+    treeSection4 = new TreeSection<>(new Comment(52, "Author 52", "Comment 52"), true);
+    treeSection5 = new TreeSection<>(new Comment(53, "Author 53", "Comment 53"), true);
+    treeSection6 = new TreeSection<>(new Comment(54, "Author 54", "Comment 54"), true);
+    treeSection7 = new TreeSection<>(new Comment(55, "Author 55", "Comment 55"), true);
+    treeSection8 = new TreeSection<>(new Comment(56, "Author 56", "Comment 56"), true);
 
     treeSection5.addSection(treeSection6);
     treeSection5.addSection(treeSection7);


### PR DESCRIPTION
1. Added a boolean param in constructor which determines whether the section should be expanded before being added to the adapter
2. notifyItemChanged method is now called when the section expansion is toggled
3. Overrides the decoration behavior from its parent.
4. Updated test case with new constructor param