### PR TITLE
Fix NPE thrown by ItemSection

### DIFF
--- a/multi-view-adapter/src/main/java/mva2/adapter/ItemSection.java
+++ b/multi-view-adapter/src/main/java/mva2/adapter/ItemSection.java
@@ -32,15 +32,15 @@ import mva2.adapter.util.Mode;
  */
 @SuppressWarnings("ConstantConditions") public class ItemSection<M> extends Section {
 
-  private M item;
-  private ItemMetaData itemMetaData;
+  @Nullable private M item;
+  @Nullable private ItemMetaData itemMetaData;
 
   /**
    * No-arg constructor for ItemSection. This sets the {@link ItemSection#item} as null. This
    * results the item not to be displayed in the recyclerview. Call {@link
    * ItemSection#setItem(Object)} to set the item.
    */
-  @SuppressWarnings("WeakerAccess") public ItemSection() {
+  public ItemSection() {
   }
 
   /**
@@ -48,9 +48,8 @@ import mva2.adapter.util.Mode;
    *
    * @param item Item that needs to be set for this ItemSection.
    */
-  public ItemSection(M item) {
-    this.item = item;
-    this.itemMetaData = new ItemMetaData();
+  public ItemSection(@NonNull M item) {
+    setItem(item);
   }
 
   /**
@@ -112,16 +111,16 @@ import mva2.adapter.util.Mode;
   }
 
   @Override boolean isItemSelected(int adapterPosition) {
-    return itemMetaData.isSelected();
+    return null != itemMetaData && itemMetaData.isSelected();
   }
 
   @Override void onItemSelectionToggled(int itemPosition, @NonNull Mode selectionMode) {
     if (itemPosition < getCount()) {
       Mode modeToHonor = getModeToHonor(selectionMode, this.selectionMode);
-      if (modeToHonor == Mode.SINGLE && itemMetaData.isSelected()) {
+      if (modeToHonor == Mode.SINGLE && null != itemMetaData && itemMetaData.isSelected()) {
         itemMetaData.setSelected(!itemMetaData.isSelected());
         onChanged(0, 1, SELECTION_PAYLOAD);
-      } else if (itemPosition < getCount() && itemPosition >= 0) {
+      } else if (itemPosition < getCount() && itemPosition >= 0 && null != itemMetaData) {
         itemMetaData.setSelected(!itemMetaData.isSelected());
         onChanged(0, 1, SELECTION_PAYLOAD);
       }
@@ -129,7 +128,7 @@ import mva2.adapter.util.Mode;
   }
 
   @Override void clearAllSelections() {
-    if (itemMetaData.isSelected()) {
+    if (null != itemMetaData && itemMetaData.isSelected()) {
       itemMetaData.setSelected(!itemMetaData.isSelected());
       if (isItemShowing()) {
         onChanged(0, 1, SELECTION_PAYLOAD);
@@ -144,10 +143,10 @@ import mva2.adapter.util.Mode;
   @Override void onItemExpansionToggled(int itemPosition, @NonNull Mode selectionMode) {
     if (itemPosition < getCount()) {
       Mode modeToHonor = getModeToHonor(selectionMode, this.expansionMode);
-      if (modeToHonor == Mode.SINGLE && itemMetaData.isExpanded()) {
+      if (modeToHonor == Mode.SINGLE && null != itemMetaData && itemMetaData.isExpanded()) {
         itemMetaData.setExpanded(!itemMetaData.isExpanded());
         onChanged(0, 1, ITEM_EXPANSION_PAYLOAD);
-      } else if (itemPosition < getCount() && itemPosition >= 0) {
+      } else if (itemPosition < getCount() && itemPosition >= 0 && null != itemMetaData) {
         itemMetaData.setExpanded(!itemMetaData.isExpanded());
         onChanged(0, 1, ITEM_EXPANSION_PAYLOAD);
       }
@@ -155,7 +154,7 @@ import mva2.adapter.util.Mode;
   }
 
   @Override void collapseAllItems() {
-    if (itemMetaData.isExpanded()) {
+    if (null != itemMetaData && itemMetaData.isExpanded()) {
       itemMetaData.setExpanded(!itemMetaData.isExpanded());
       if (isItemShowing()) {
         onChanged(0, 1, ITEM_EXPANSION_PAYLOAD);

--- a/multi-view-adapter/src/test/java/mva2/adapter/MultiViewAdapterTest.java
+++ b/multi-view-adapter/src/test/java/mva2/adapter/MultiViewAdapterTest.java
@@ -172,6 +172,8 @@ public class MultiViewAdapterTest extends BaseTest {
   @Test public void collapseAll_test() {
     adapter.collapseAllSections();
     assertEquals(adapter.getItemCount(), 32);
+    assertFalse(adapter.isSectionExpanded(19));
+    assertFalse(adapter.isSectionExpanded(30));
   }
 
   @Test public void clearSelections_test() {
@@ -204,6 +206,46 @@ public class MultiViewAdapterTest extends BaseTest {
     assertEquals(listSection2.getSelectedItems().size(), 0);
     assertEquals(listSection3.getSelectedItems().size(), 0);
     assertEquals(listSection4.getSelectedItems().size(), 0);
+  }
+
+  @Test public void clearItemExpansions_test() {
+    // Expand multiple items from different sections
+    // Collapse all items
+    // Check the expanded items from different section
+
+    adapter.setExpansionMode(Mode.MULTIPLE);
+
+    adapter.onItemExpansionToggled(0);
+
+    adapter.onItemExpansionToggled(1);
+    adapter.onItemExpansionToggled(2);
+    adapter.onItemExpansionToggled(3);
+    adapter.onItemExpansionToggled(4);
+
+    adapter.onItemExpansionToggled(20);
+    adapter.onItemExpansionToggled(21);
+
+    adapter.onItemExpansionToggled(34);
+    adapter.onItemExpansionToggled(35);
+    adapter.onItemExpansionToggled(44);
+    adapter.onItemExpansionToggled(45);
+
+    adapter.collapseAllItems();
+
+    assertFalse(adapter.isItemExpanded(0));
+
+    assertFalse(adapter.isItemExpanded(1));
+    assertFalse(adapter.isItemExpanded(2));
+    assertFalse(adapter.isItemExpanded(3));
+    assertFalse(adapter.isItemExpanded(4));
+
+    assertFalse(adapter.isItemExpanded(20));
+    assertFalse(adapter.isItemExpanded(21));
+
+    assertFalse(adapter.isItemExpanded(34));
+    assertFalse(adapter.isItemExpanded(35));
+    assertFalse(adapter.isItemExpanded(44));
+    assertFalse(adapter.isItemExpanded(45));
   }
 
   @Test public void removeAllSections_test() {


### PR DESCRIPTION
ItemSection when added to an adapter and is not initialized with an item, throws NPE when expansion/selection is toggled. Check whether the item is initialized before accessing the expansion/selection fixes the issue.