### PR TITLE
Fix incorrect window insets in sample app

### DIFF
--- a/sample/src/main/java/dev/ahamed/mva/sample/view/basic/BasicSampleFragment.java
+++ b/sample/src/main/java/dev/ahamed/mva/sample/view/basic/BasicSampleFragment.java
@@ -91,7 +91,8 @@ public class BasicSampleFragment extends BaseFragment {
     adapter.removeAllSections();
 
     if (PreferenceManager.getDefaultSharedPreferences(requireContext().getApplicationContext())
-        .getBoolean(SampleActivity.PREFS_HINT_ENABLED, true)) {
+        .getBoolean(SampleActivity.PREFS_HINT_ENABLED, true)
+        && spinnerOrientation.getSelectedItemPosition() == 0) {
       adapter.registerItemBinders(new HintBinder());
       adapter.addSection(new ItemSection<>(new Hint(getHint())));
       adapter.getItemTouchHelper().attachToRecyclerView(recyclerView);

--- a/sample/src/main/java/dev/ahamed/mva/sample/view/home/HomeFragment.java
+++ b/sample/src/main/java/dev/ahamed/mva/sample/view/home/HomeFragment.java
@@ -131,7 +131,7 @@ public class HomeFragment extends Fragment {
         "Do you want a section which directly accepts observable? Do you want your "
             + "viewholder to directly support ButterKnife?\nNow write your own extension. The "
             + "library has very good api set to utilise and build your own extension.\nTake a look "
-            + "at DataBinding extension for getting started."));
+            + "at DataBinding extension or RxDiffUtil extension for getting started."));
 
     return features;
   }

--- a/sample/src/main/java/dev/ahamed/mva/sample/view/widget/BottomBar.java
+++ b/sample/src/main/java/dev/ahamed/mva/sample/view/widget/BottomBar.java
@@ -24,7 +24,8 @@ public class BottomBar extends FrameLayout {
 
   public void setInsetsListener() {
     setOnApplyWindowInsetsListener((v, insets) -> {
-      v.setPadding(0, 0, 0, insets.getSystemWindowInsetBottom());
+      v.setPadding(insets.getSystemWindowInsetLeft(), 0, insets.getSystemWindowInsetRight(),
+          insets.getSystemWindowInsetBottom());
       return insets;
     });
   }

--- a/sample/src/main/java/dev/ahamed/mva/sample/view/widget/InsetFrameLayout.java
+++ b/sample/src/main/java/dev/ahamed/mva/sample/view/widget/InsetFrameLayout.java
@@ -29,8 +29,8 @@ public class InsetFrameLayout extends FrameLayout {
     context.getTheme().resolveAttribute(R.attr.actionBarSize, typedValue, true);
     int actionBarSize = (int) getResources().getDimension(typedValue.resourceId);
     setOnApplyWindowInsetsListener((v, insets) -> {
-      //v.setPadding(0, insets.getSystemWindowInsetTop() + actionBarSize, 0,
-      //    insets.getSystemWindowInsetBottom() + actionBarSize);
+      v.setPadding(insets.getSystemWindowInsetLeft(), 0,
+          insets.getSystemWindowInsetRight(), 0);
       return insets;
     });
   }

--- a/sample/src/main/java/dev/ahamed/mva/sample/view/widget/TopBar.java
+++ b/sample/src/main/java/dev/ahamed/mva/sample/view/widget/TopBar.java
@@ -24,7 +24,8 @@ public class TopBar extends FrameLayout {
 
   public void setInsetsListener() {
     setOnApplyWindowInsetsListener((v, insets) -> {
-      v.setPadding(0, insets.getSystemWindowInsetTop(), 0, 0);
+      v.setPadding(insets.getSystemWindowInsetLeft(), insets.getSystemWindowInsetTop(),
+          insets.getSystemWindowInsetRight(), 0);
       return insets;
     });
   }

--- a/sample/src/main/java/dev/ahamed/mva/sample/view/widget/WindowInsetsFrameLayout.java
+++ b/sample/src/main/java/dev/ahamed/mva/sample/view/widget/WindowInsetsFrameLayout.java
@@ -33,9 +33,9 @@ public class WindowInsetsFrameLayout extends FrameLayout {
 
   @Override public WindowInsets onApplyWindowInsets(WindowInsets insets) {
     int childCount = getChildCount();
-    for (int index = 0; index < childCount; index++)
+    for (int index = 0; index < childCount; index++) {
       getChildAt(index).dispatchApplyWindowInsets(insets);
-
+    }
     return insets;
   }
 }


### PR DESCRIPTION
Incorrect insets were set in landscape mode ie., Content goes behind without any scrim under navigation bar. This commit fixes the issue by adding left and right padding to the window inset.