### PR TITLE
Show/hide child sections when NestedSection's show/hide api is called

### DIFF
--- a/multi-view-adapter/src/main/java/mva3/adapter/NestedSection.java
+++ b/multi-view-adapter/src/main/java/mva3/adapter/NestedSection.java
@@ -60,6 +60,24 @@ public class NestedSection extends Section implements Notifier {
     section.onInserted(0, section.getCount());
   }
 
+  @Override public void showSection() {
+    if (isSectionHidden()) {
+      for (Section section : sections) {
+        section.showSection(false);
+      }
+    }
+    super.showSection();
+  }
+
+  @Override public void hideSection() {
+    if (isSectionVisible()) {
+      for (Section section : sections) {
+        section.hideSection(false);
+      }
+    }
+    super.hideSection();
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////
   /// ------------------------------------------------------------------------------ ///
   /// ---------------------  CAUTION : INTERNAL METHODS AHEAD  --------------------- ///

--- a/multi-view-adapter/src/main/java/mva3/adapter/Section.java
+++ b/multi-view-adapter/src/main/java/mva3/adapter/Section.java
@@ -128,11 +128,7 @@ public abstract class Section implements ListUpdateCallback {
    * Section#getCount()} returns 0.
    */
   public void hideSection() {
-    if (!isSectionHidden) {
-      int count = getCount();
-      isSectionHidden = true;
-      onRemoved(0, count);
-    }
+    hideSection(true);
   }
 
   /**
@@ -235,11 +231,7 @@ public abstract class Section implements ListUpdateCallback {
    * If the section was hidden from parent, this method shows it again in the parent.
    */
   public void showSection() {
-    if (isSectionHidden) {
-      isSectionHidden = false;
-      onDataSetChanged();
-      onInserted(0, getCount());
-    }
+    showSection(true);
   }
 
   //////////////////////////////////////////////////////////////////////////////////////
@@ -354,6 +346,26 @@ public abstract class Section implements ListUpdateCallback {
 
   void onDataSetChanged() {
     // No-op
+  }
+
+  void showSection(boolean notify) {
+    if (isSectionHidden) {
+      isSectionHidden = false;
+      onDataSetChanged();
+      if (notify) {
+        onInserted(0, getCount());
+      }
+    }
+  }
+
+  void hideSection(boolean notify) {
+    if (!isSectionHidden) {
+      int count = getCount();
+      isSectionHidden = true;
+      if (notify) {
+        onRemoved(0, count);
+      }
+    }
   }
 
   @NonNull Mode getModeToHonor(@NonNull Mode parentMode, @NonNull Mode childMode) {

--- a/multi-view-adapter/src/test/java/mva3/adapter/CoreExpansionTest.java
+++ b/multi-view-adapter/src/test/java/mva3/adapter/CoreExpansionTest.java
@@ -24,6 +24,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class) public class CoreExpansionTest extends BaseTest {
 
@@ -178,5 +182,43 @@ import static junit.framework.Assert.assertTrue;
 
     adapter.onItemExpansionToggled(25);
     assertTrue(!adapter.isItemExpanded(25));
+  }
+
+  @Test public void expansionModeTest_Notify() {
+    adapter.setExpansionMode(Mode.MULTIPLE);
+    listSection1.setExpansionMode(Mode.MULTIPLE);
+    listSection2.setExpansionMode(Mode.MULTIPLE);
+
+    adapter.onItemExpansionToggled(1);
+    adapter.onItemExpansionToggled(41);
+    adapter.onItemExpansionToggled(2);
+    adapter.onItemExpansionToggled(25);
+    adapter.onItemExpansionToggled(28);
+
+    clearInvocations(adapterDataObserver);
+    adapter.collapseAllItems();
+
+    verify(adapterDataObserver).notifyItemRangeChanged(eq(1), eq(1), any());
+    verify(adapterDataObserver).notifyItemRangeChanged(eq(41), eq(1), any());
+    verify(adapterDataObserver).notifyItemRangeChanged(eq(2), eq(1), any());
+    verify(adapterDataObserver).notifyItemRangeChanged(eq(25), eq(1), any());
+    verify(adapterDataObserver).notifyItemRangeChanged(eq(28), eq(1), any());
+  }
+
+  @Test public void expansionModeTest_NestedSection() {
+    adapter.setExpansionMode(Mode.MULTIPLE);
+    listSection1.setExpansionMode(Mode.SINGLE);
+    listSection2.setExpansionMode(Mode.SINGLE);
+    listSection3.setExpansionMode(Mode.SINGLE);
+    listSection4.setExpansionMode(Mode.SINGLE);
+    adapter.onSectionExpansionToggled(19);
+
+    adapter.onItemExpansionToggled(21);
+    assertTrue(adapter.isItemExpanded(21));
+
+    adapter.onSectionExpansionToggled(19);
+
+    assertFalse(adapter.isItemExpanded(21));
+    assertTrue(adapter.isItemExpanded(30));
   }
 }

--- a/multi-view-adapter/src/test/java/mva3/adapter/CoreSelectionTest.java
+++ b/multi-view-adapter/src/test/java/mva3/adapter/CoreSelectionTest.java
@@ -197,4 +197,22 @@ import static org.mockito.Mockito.verify;
     verify(adapterDataObserver).notifyItemRangeChanged(eq(25), eq(1), any());
     verify(adapterDataObserver).notifyItemRangeChanged(eq(28), eq(1), any());
   }
+
+  @Test public void selectionModeTest_NestedSection() {
+    adapter.setSelectionMode(Mode.MULTIPLE);
+    listSection1.setSelectionMode(Mode.SINGLE);
+    listSection2.setSelectionMode(Mode.SINGLE);
+    listSection3.setSelectionMode(Mode.SINGLE);
+    listSection4.setSelectionMode(Mode.SINGLE);
+    adapter.onSectionExpansionToggled(19);
+
+    adapter.onItemSelectionToggled(21);
+
+    assertTrue(adapter.isItemSelected(21));
+
+    adapter.onSectionExpansionToggled(19);
+
+    assertFalse(adapter.isItemSelected(21));
+    assertTrue(adapter.isItemSelected(30));
+  }
 }


### PR DESCRIPTION
Previously when the NestedSection is being shown or hidden, its child section's visibilities are untouched. But this might create issues when selection or expansion is toggled ie., incorrect selection / expansion flags are set to the child section even though the parent's is not visible in the adapter. So we set visibility to all child section which will produce the correct behavior.

Note : This change was cloned from 2.x branch