### PR TITLE
Add the HeaderSections rather than the sections themselves.

### DIFF
--- a/sample/src/main/java/dev/ahamed/mva/sample/view/decoration/DecorationSampleFragment.java
+++ b/sample/src/main/java/dev/ahamed/mva/sample/view/decoration/DecorationSampleFragment.java
@@ -121,9 +121,9 @@ public class DecorationSampleFragment extends BaseFragment {
     personBinder = new PersonBinder();
 
     adapter.registerItemBinders(personBinder, headerBinder);
-    adapter.addSection(castSection);
-    adapter.addSection(crewSection);
-    adapter.addSection(producerSection);
+    adapter.addSection(castHeaderSection);
+    adapter.addSection(crewHeaderSection);
+    adapter.addSection(producerHeaderSection);
 
     castSection.set(dataManager.getCast());
     crewSection.set(dataManager.getCrew());


### PR DESCRIPTION
The `xxxSection` is being added to the adapter, rather than the enclosing `xxxHeaderSection`. Error is reported by addSection throwing `IllegalStateException("Section is already has a parent!")`